### PR TITLE
ensure that eof line is placed correctly at end of newly written file

### DIFF
--- a/system/pam_limits.py
+++ b/system/pam_limits.py
@@ -144,11 +144,15 @@ def main():
     nf = tempfile.NamedTemporaryFile(delete = False)
 
     found = False
+    has_eof = False
     new_value = value
 
     for line in f:
 
-        if line.startswith('#'):
+        if line.startswith('# End of file'):
+            has_eof = True
+            continue
+        elif line.startswith('#'):
             nf.write(line)
             continue
 
@@ -214,6 +218,9 @@ def main():
         new_limit = domain + "\t" + limit_type + "\t" + limit_item + "\t" + str(new_value) + new_comment + "\n"
         message = new_limit
         nf.write(new_limit)
+
+    if has_eof:
+      nf.write("# End of file")
 
     f.close()
     nf.close()


### PR DESCRIPTION
The default `limits.conf` file on Red Hat / CentOS systems has a seperate line which indicates that the end of the file has been reached:

    drew@host# tail -1 /etc/security/limits.conf
    # End of file

Currently, the `pam_limits.conf` module treats this as a standard comment and writes it to the same position in the file that it is currently.  When limits are added, they're written *after* the end-of-file indicator as so:

    user1     soft    nproc   4096
    user1     hard    nproc   4096
    # End of file
    user2     soft    nproc   16384
    user2     hard    nofile  18192

This patch ensures that the end-of-file line is written appropriately to the end of the newly created file.  The resultant  `limits.conf` as compared with above will now look like so:

    user1     soft    nproc   4096
    user1     hard    nproc   4096
    user2     soft    nproc   16384
    user2     hard    nofile  18192
    # End of file


 